### PR TITLE
recipes-zarhus: add devmem2 and libgpiod to debug package

### DIFF
--- a/recipes-zarhus/packagegroups/packagegroup-zarhus.bb
+++ b/recipes-zarhus/packagegroups/packagegroup-zarhus.bb
@@ -3,6 +3,8 @@ DESCRIPTION = "zarhus packagegroup"
 
 LICENSE = "MIT"
 
+PACKAGE_ARCH = "${TUNE_PKGARCH}"
+
 inherit packagegroup
 
 PACKAGES = " \
@@ -18,4 +20,7 @@ RDEPENDS:${PN}-system = " \
 
 RDEPENDS:${PN}-dbg = " \
     gzip \
+    libgpiod \
+    libgpiod-tools \
+    devmem2 \
 "


### PR DESCRIPTION
Packages that might be useful for debugging.
`libgpiod-tools` may be used to check or set GPIOs while `devmem2` is useful for reading and modifying device registers.

`PACKAGE_ARCH = "${TUNE_PKGARCH}"` was needed to deal with `An allarch packagegroup shouldn't depend on packages which are dynamically renamed` QA error.