### PR TITLE
recipes-zarhus: images: zarhus-base-image-debug: delete

### DIFF
--- a/.oelint-custom-overrides.json
+++ b/.oelint-custom-overrides.json
@@ -1,0 +1,7 @@
+{
+  "replacements": {
+    "distros": [
+      "dbg"
+    ]
+  }
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
     rev: 5.7.2
     hooks:
       - id: oelint-adv
-        args: [--rulefile=.oelint-ruleset.json, --hide=info, --quiet, --fix]
+        args: [--rulefile=.oelint-ruleset.json, --constantmods=+.oelint-custom-overrides.json, --hide=info, --quiet, --fix]
         name: Advanced oelint
         description: Based on the OpenEmbedded Styleguide and work done by oe-stylize-tool this module offers a (nearly) complete linter for bitbake-recipes.
         entry: oelint-adv

--- a/meta-zarhus-distro/recipes-zarhus/images/zarhus-base-image-debug.bb
+++ b/meta-zarhus-distro/recipes-zarhus/images/zarhus-base-image-debug.bb
@@ -1,7 +1,0 @@
-require zarhus-base-image.inc
-
-IMAGE_FEATURES += "debug-tweaks"
-
-IMAGE_INSTALL:append = " \
-    packagegroup-zarhus-dbg \
-"

--- a/meta-zarhus-distro/recipes-zarhus/images/zarhus-base-image.inc
+++ b/meta-zarhus-distro/recipes-zarhus/images/zarhus-base-image.inc
@@ -1,6 +1,7 @@
 SUMMARY = "zarhus image"
 
-IMAGE_FEATURES += "ssh-server-openssh"
+IMAGE_FEATURES += " ssh-server-openssh"
+IMAGE_FEATURES:dbg += " debug-tweaks"
 
 LICENSE = "MIT"
 
@@ -8,4 +9,8 @@ inherit core-image
 
 IMAGE_INSTALL:append = " \
     packagegroup-zarhus-system \
+"
+
+IMAGE_INSTALL:append:dbg = " \
+    packagegroup-zarhus-dbg \
 "


### PR DESCRIPTION
We can use overrides to add debug functionalities to images, this will decrease amount of images files, improve scalability and maintenance. This has been originally proposed here https://github.com/zarhus/meta-zarhus/pull/15#discussion_r1709655526.