### PR TITLE
recipes-zarhus: add alsa to separate packagegroups

### DIFF
--- a/meta-zarhus-distro/recipes-zarhus/packagegroups/packagegroup-zarhus.bb
+++ b/meta-zarhus-distro/recipes-zarhus/packagegroups/packagegroup-zarhus.bb
@@ -10,6 +10,7 @@ inherit packagegroup
 PACKAGES = " \
     ${PN}-system \
     ${PN}-dbg \
+    ${PN}-alsa \
 "
 
 RDEPENDS:${PN}-system = " \
@@ -23,4 +24,23 @@ RDEPENDS:${PN}-dbg = " \
     libgpiod \
     libgpiod-tools \
     devmem2 \
+"
+
+# FIXME:
+# 1. Do we need all of these?
+# 2. Apparently, alsa-mixer needed the dialog and ncurses, if that is the case,
+# it should be fixed in the upstream alsa recipe.
+
+RDEPENDS:${PN}-alsa = " \
+    packagegroup-base-alsa \
+    alsa-utils-speakertest \
+    alsa-utils \
+    alsa-plugins \
+    alsa-lib \
+    alsa-tools \
+    libasound \
+    mpg123 \
+    gettext \
+    dialog \
+    ncurses \
 "


### PR DESCRIPTION
This patch adds packagegroups:
* zarhus-alsa
* zarhus-alsa-tools