### PR TITLE
Add libdrm-tests to dbg package

### DIFF
--- a/meta-zarhus-distro/recipes-zarhus/packagegroups/packagegroup-zarhus.bb
+++ b/meta-zarhus-distro/recipes-zarhus/packagegroups/packagegroup-zarhus.bb
@@ -24,6 +24,7 @@ RDEPENDS:${PN}-dbg = " \
     libgpiod \
     libgpiod-tools \
     devmem2 \
+    libdrm-tests \
 "
 
 # FIXME:


### PR DESCRIPTION
libdrm-tests contains e.g. 'modetest' which is useful for drm debugging