### PR TITLE
Move common distro parts to include file to reduce code duplication

### DIFF
--- a/meta-zarhus-distro/conf/distro/include/zarhus-distro-common.conf
+++ b/meta-zarhus-distro/conf/distro/include/zarhus-distro-common.conf
@@ -1,7 +1,5 @@
 require conf/distro/poky.conf
 
-# distro name
-DISTRO_NAME = "Distro for Zarhus product"
 DISTRO_VERSION = "0.1.0"
 SDK_VENDOR = "-zarhussdk"
 
@@ -9,7 +7,6 @@ MAINTAINER = "3mdeb Sp. z o. o. <contact@3mdeb.com>"
 
 TARGET_VENDOR = "-zarhus"
 
-# distro features
 # DISTRO_FEATURES_DEFAULT ?= "acl alsa argp bluetooth ext2 ipv4 ipv6 largefile pcmcia usbgadget usbhost wifi xattr nfs zeroconf pci 3g nfc x11 vfat"
 # POKY_DEFAULT_DISTRO_FEATURES = "largefile opengl ptest multiarch wayland vulkan"
 DISTRO_FEATURES = "${DISTRO_FEATURES_DEFAULT} systemd usrmerge"

--- a/meta-zarhus-distro/conf/distro/include/zarhus-distro-common.conf
+++ b/meta-zarhus-distro/conf/distro/include/zarhus-distro-common.conf
@@ -1,0 +1,33 @@
+require conf/distro/poky.conf
+
+# distro name
+DISTRO_NAME = "Distro for Zarhus product"
+DISTRO_VERSION = "0.1.0"
+SDK_VENDOR = "-zarhussdk"
+
+MAINTAINER = "3mdeb Sp. z o. o. <contact@3mdeb.com>"
+
+TARGET_VENDOR = "-zarhus"
+
+# distro features
+# DISTRO_FEATURES_DEFAULT ?= "acl alsa argp bluetooth ext2 ipv4 ipv6 largefile pcmcia usbgadget usbhost wifi xattr nfs zeroconf pci 3g nfc x11 vfat"
+# POKY_DEFAULT_DISTRO_FEATURES = "largefile opengl ptest multiarch wayland vulkan"
+DISTRO_FEATURES = "${DISTRO_FEATURES_DEFAULT} systemd usrmerge"
+
+# explicitly use systemd and disable sysvinit completely
+VIRTUAL-RUNTIME_init_manager = "systemd"
+VIRTUAL-RUNTIME_initscripts = ""
+VIRTUAL-RUNTIME_syslog = ""
+DISTRO_FEATURES_BACKFILL_CONSIDERED += "sysvinit pulseaudio"
+
+ROOT_PASSWORD = "OZuZFzdcWUJMls5k5u7ErPhRvMQTHh0V"
+# According to https://docs.yoctoproject.org/singleindex.html#extrausers-bbclass
+# mkpasswd should be used in order to set account password, this password for
+# root was created with the meta-zarhus layer using the following command:
+# `printf "%q" $(mkpasswd -m sha256crypt $ROOT_PASSWORD)`
+# TODO: add way to automate generating ROOT_PASSWD, maybe split this before vs
+# after honister update, because the method changed
+ROOT_PASSWD = "TODO"
+
+
+IMAGE_FSTYPES = "wic.gz wic.bmap"

--- a/meta-zarhus-distro/conf/distro/zarhus-distro-webkit.conf
+++ b/meta-zarhus-distro/conf/distro/zarhus-distro-webkit.conf
@@ -1,37 +1,11 @@
-require conf/distro/poky.conf
+require conf/distro/include/zarhus-distro-common.conf
 
 DISTRO = "zarhus-distro-webkit"
-
-# distro name
 DISTRO_NAME = "Distro for Zarhus product with WebKit support"
-DISTRO_VERSION = "0.1.0"
-SDK_VENDOR = "-zarhussdk"
 
-MAINTAINER = "3mdeb Sp. z o. o. <contact@3mdeb.com>"
+# We can add suffix to main version if only Webkit distro changes e.g.
+# 0.1.0-1.0.0.
+DISTRO_VERSION:append = ""
 
-TARGET_VENDOR = "-zarhus"
-
-# distro features
-# DISTRO_FEATURES_DEFAULT ?= "acl alsa argp bluetooth ext2 ipv4 ipv6 largefile pcmcia usbgadget usbhost wifi xattr nfs zeroconf pci 3g nfc x11 vfat"
-# POKY_DEFAULT_DISTRO_FEATURES = "largefile opengl ptest multiarch wayland vulkan"
-DISTRO_FEATURES = "${DISTRO_FEATURES_DEFAULT} systemd usrmerge"
-
-# explicitly use systemd and disable sysvinit completely
-VIRTUAL-RUNTIME_init_manager = "systemd"
-VIRTUAL-RUNTIME_initscripts = ""
-VIRTUAL-RUNTIME_syslog = ""
-DISTRO_FEATURES_BACKFILL_CONSIDERED += "sysvinit pulseaudio"
-
-ROOT_PASSWORD = "OZuZFzdcWUJMls5k5u7ErPhRvMQTHh0V"
-# According to https://docs.yoctoproject.org/singleindex.html#extrausers-bbclass
-# mkpasswd should be used in order to set account password, this password for
-# root was created with the meta-zarhus layer using the following command:
-# `printf "%q" $(mkpasswd -m sha256crypt $ROOT_PASSWORD)`
-# TODO: add way to automate generating ROOT_PASSWD, maybe split this before vs
-# after honister update, because the method changed
-ROOT_PASSWD = "TODO"
-
-
-IMAGE_FSTYPES = "wic.gz wic.bmap"
 
 require conf/distro/include/zarhus-webkit.conf

--- a/meta-zarhus-distro/conf/distro/zarhus-distro-webkit.conf
+++ b/meta-zarhus-distro/conf/distro/zarhus-distro-webkit.conf
@@ -3,9 +3,4 @@ require conf/distro/include/zarhus-distro-common.conf
 DISTRO = "zarhus-distro-webkit"
 DISTRO_NAME = "Distro for Zarhus product with WebKit support"
 
-# We can add suffix to main version if only Webkit distro changes e.g.
-# 0.1.0-1.0.0.
-DISTRO_VERSION:append = ""
-
-
 require conf/distro/include/zarhus-webkit.conf

--- a/meta-zarhus-distro/conf/distro/zarhus-distro.conf
+++ b/meta-zarhus-distro/conf/distro/zarhus-distro.conf
@@ -1,35 +1,4 @@
 require conf/distro/poky.conf
 
 DISTRO = "zarhus-distro"
-
-# distro name
 DISTRO_NAME = "Distro for Zarhus product"
-DISTRO_VERSION = "0.1.0"
-SDK_VENDOR = "-zarhussdk"
-
-MAINTAINER = "3mdeb Sp. z o. o. <contact@3mdeb.com>"
-
-TARGET_VENDOR = "-zarhus"
-
-# distro features
-# DISTRO_FEATURES_DEFAULT ?= "acl alsa argp bluetooth ext2 ipv4 ipv6 largefile pcmcia usbgadget usbhost wifi xattr nfs zeroconf pci 3g nfc x11 vfat"
-# POKY_DEFAULT_DISTRO_FEATURES = "largefile opengl ptest multiarch wayland vulkan"
-DISTRO_FEATURES = "${DISTRO_FEATURES_DEFAULT} systemd usrmerge"
-
-# explicitly use systemd and disable sysvinit completely
-VIRTUAL-RUNTIME_init_manager = "systemd"
-VIRTUAL-RUNTIME_initscripts = ""
-VIRTUAL-RUNTIME_syslog = ""
-DISTRO_FEATURES_BACKFILL_CONSIDERED += "sysvinit pulseaudio"
-
-ROOT_PASSWORD = "OZuZFzdcWUJMls5k5u7ErPhRvMQTHh0V"
-# According to https://docs.yoctoproject.org/singleindex.html#extrausers-bbclass
-# mkpasswd should be used in order to set account password, this password for
-# root was created with the meta-zarhus layer using the following command:
-# `printf "%q" $(mkpasswd -m sha256crypt $ROOT_PASSWORD)`
-# TODO: add way to automate generating ROOT_PASSWD, maybe split this before vs
-# after honister update, because the method changed
-ROOT_PASSWD = "TODO"
-
-
-IMAGE_FSTYPES = "wic.gz wic.bmap"


### PR DESCRIPTION
About `DISTRO_VERSION:append = ""` we can either add sub-version to main one or remove it altogether and keep one version for both distros otherwise it might be missed.