### PR TITLE
pre-commit: oelint: add dbg to known overrides database

### DIFF
--- a/.oelint-custom-overrides.json
+++ b/.oelint-custom-overrides.json
@@ -1,0 +1,7 @@
+{
+    "replacements": {
+        "distros": [
+            "dbg"
+        ]
+    }
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
     rev: 5.7.2
     hooks:
       - id: oelint-adv
-        args: [--rulefile=.oelint-ruleset.json, --hide=info, --quiet, --fix]
+        args: [--rulefile=.oelint-ruleset.json, --hide=info, --quiet, --fix, --constantmods=+.oelint-custom-overrides.json]
         name: Advanced oelint
         description: Based on the OpenEmbedded Styleguide and work done by oe-stylize-tool this module offers a (nearly) complete linter for bitbake-recipes.
         entry: oelint-adv


### PR DESCRIPTION
Without it oelint might complain e.g. when using dbg override on tasks e.g. `do_install:append:dbg`