### PR TITLE
Use vim instead of vim-tiny

### DIFF
--- a/meta-zarhus-distro/conf/distro/include/zarhus-distro-common.conf
+++ b/meta-zarhus-distro/conf/distro/include/zarhus-distro-common.conf
@@ -15,6 +15,7 @@ DISTRO_FEATURES = "${DISTRO_FEATURES_DEFAULT} systemd usrmerge"
 VIRTUAL-RUNTIME_init_manager = "systemd"
 VIRTUAL-RUNTIME_initscripts = ""
 VIRTUAL-RUNTIME_syslog = ""
+VIRTUAL-RUNTIME_vim = "vim"
 DISTRO_FEATURES_BACKFILL_CONSIDERED += "sysvinit pulseaudio"
 
 ROOT_PASSWORD = "OZuZFzdcWUJMls5k5u7ErPhRvMQTHh0V"

--- a/meta-zarhus-distro/recipes-support/vim/vim_%.bbappend
+++ b/meta-zarhus-distro/recipes-support/vim/vim_%.bbappend
@@ -1,0 +1,26 @@
+FIX_HOME_END_KEYS = "1"
+# don't create "<file>~" files
+NO_BACKUP_FILE = "1"
+# don't create ".<file>.un~" files
+NO_UNDO_FILE = "1"
+
+do_install:append() {
+    defaults_file="${D}${datadir}/vim/vim91/defaults.vim"
+    if [ "${FIX_HOME_END_KEYS}" = "1" ]; then
+        # Make sure HOME/END keys work
+        echo "map <esc>OH <home>" >> "${defaults_file}"
+        echo "cmap <esc>OH <home>" >> "${defaults_file}"
+        echo "imap <esc>OH <home>" >> "${defaults_file}"
+        echo "map <esc>OF <end>" >> "${defaults_file}"
+        echo "cmap <esc>OF <end>" >> "${defaults_file}"
+        echo "imap <esc>OF <end>" >> "${defaults_file}"
+    fi
+
+    if [ "${NO_BACKUP_FILE}" = "1" ]; then
+        echo "set nobackup" >> "${defaults_file}"
+    fi
+
+    if [ "${NO_UNDO_FILE}" = "1" ]; then
+        echo "set noundofile" >> "${defaults_file}"
+    fi
+}


### PR DESCRIPTION
Fixes annoying error:

```
E1187: Failed to source defaults.vim
Press ENTER or type command to continue
```

* Shows which mode we are in (e.g. insert/visual...).
* Arrow keys work in insert mode.
* HOME/END keys move cursor to the beginning and end of line.

And more.