### PR TITLE
kas: add kas menu support

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -1,0 +1,4 @@
+KAS_DIR := kas
+MACHINE_DIR := $(KAS_DIR)/machine
+
+source "kas/Kconfig"

--- a/README.md
+++ b/README.md
@@ -32,6 +32,42 @@ script downloaded and available in [PATH](https://en.wikipedia.org/wiki/PATH_(va
   > [from GitHub](https://github.com/yoctoproject/bmaptool) if it is not
   > available in your distro.
 
+## Configuration
+
+To configure different features or target machine to build for you can either
+pass `.yml` files and set `KAS_*` variables manually or for easier configuration
+you can use:
+
+```sh
+kas-container menu meta-zarhus/Kconfig
+```
+
+After which you can select desired options
+
+```text
+┌──────────────────────┤ Main menu ├───────────────────────┐
+│                                                          │
+│                        Machine  --->                     │
+│                        Distro  --->                      │
+│                        Features  --->                    │
+│                                                          │
+│  ┌───────┐   ┌─────────────┐   ┌────────┐   ┌────────┐   │
+│  │ Build │   │ Save & Exit │   │  Exit  │   │  Help  │   │
+│  └───────┘   └─────────────┘   └────────┘   └────────┘   │
+│                                                          │
+│                                                          │
+└──────────────────────────────────────────────────────────┘
+```
+
+After saving your first config you can then use `menu`/`build`/`shell` kas
+subcommands without passing config argument e.g.:
+
+```sh
+kas-container menu
+kas-container shell
+kas-container build
+```
+
 ## Build
 
 Depending on which features you want to have in your build, pass the desired

--- a/kas/Kconfig
+++ b/kas/Kconfig
@@ -1,0 +1,51 @@
+config KAS_INCLUDE_COMMON
+	string
+	default "$(KAS_DIR)/common.yml"
+
+source "kas/machine/Kconfig"
+
+menu "Distro"
+
+choice
+	prompt "Select distribution"
+	default ZARHUS_DISTRO
+
+config ZARHUS_DISTRO
+	bool "Distro for Zarhus product"
+
+config ZARHUS_DISTRO_WEBKIT
+	bool "Distro for Zarhus product with WebKit support"
+
+endchoice
+
+config KAS_INCLUDE_DISTRO
+	string
+	default "$(KAS_DIR)/webkit.yml" if ZARHUS_DISTRO_WEBKIT
+
+endmenu
+
+menu "Features"
+
+config DEBUG
+	bool "Debug features"
+	help
+		Add debug features such as passwordless root account, enable additional
+		Linux kernel configs such as debugfs, add applications that might be
+		helpful with debugging such as gdb or devmem
+
+config KAS_INCLUDE_DEBUG
+	string
+	default "$(KAS_DIR)/debug.yml"
+	depends on DEBUG
+
+config CACHE
+	bool "Enable use of cache"
+	help
+		Enable use of remote cache (configured in cache.yml)
+
+config KAS_INCLUDE_CACHE
+	string
+	default "$(KAS_DIR)/cache.yml"
+	depends on CACHE
+
+endmenu

--- a/kas/machine/Kconfig
+++ b/kas/machine/Kconfig
@@ -1,0 +1,33 @@
+menu "Machine"
+
+choice
+	prompt "Which machine/platform to build for"
+	default RADXA_CM3
+
+config ORANGEPI_CM4
+	bool "Orange Pi CM4"
+
+config QUARTZ64_A
+	bool "Quartz64 Model A"
+
+config RADXA_CM3
+	bool "RadxaCM3"
+
+config RPI4
+	bool "Raspberry Pi 4"
+
+endchoice
+
+config KAS_INCLUDE_MACHINE
+	string
+	default "$(MACHINE_DIR)/orangepi-cm4.yml" if ORANGEPI_CM4
+	default "$(MACHINE_DIR)/quartz64-a.yml" if QUARTZ64_A
+	default "$(MACHINE_DIR)/radxa-cm3.yml" if RADXA_CM3
+	default "$(MACHINE_DIR)/raspberrypi4.yml" if RPI4
+
+config KAS_INCLUDE_BSP
+	string
+	default "$(KAS_DIR)/rockchip.yml" if ORANGEPI_CM4 || QUARTZ64_A || RADXA_CM3
+	default "$(KAS_DIR)/rpi.yml" if RPI4
+
+endmenu

--- a/kas/machine/orangepi-cm4.yml
+++ b/kas/machine/orangepi-cm4.yml
@@ -1,0 +1,5 @@
+---
+header:
+  version: 11
+
+machine: orangepi-cm4

--- a/kas/machine/quartz64-a.yml
+++ b/kas/machine/quartz64-a.yml
@@ -1,0 +1,5 @@
+---
+header:
+  version: 11
+
+machine: quartz64-a

--- a/kas/machine/radxa-cm3.yml
+++ b/kas/machine/radxa-cm3.yml
@@ -1,0 +1,5 @@
+---
+header:
+  version: 11
+
+machine: radxa-cm3

--- a/kas/machine/raspberrypi4.yml
+++ b/kas/machine/raspberrypi4.yml
@@ -1,0 +1,5 @@
+---
+header:
+  version: 11
+
+machine: raspberrypi4


### PR DESCRIPTION
Add support for easy build configuration via `kas-container menu` while making sure building the old way works as before:

![image](https://github.com/user-attachments/assets/9d0c8ee2-1ba3-44bb-89df-f9a91f97c0fd)

Currently we have to create separate `yml` file for each machine due to https://github.com/siemens/kas/issues/154.
Resolves https://github.com/zarhus/zarhus-issues/issues/19