### PR TITLE
zarhus-features: don't print resize2fs header and gpt warning

### DIFF
--- a/meta-zarhus-features/meta-otab/meta-otab-uki/dynamic-layers/zarhus-encryption/recipes-zarhus/images/otab-encryption.inc
+++ b/meta-zarhus-features/meta-otab/meta-otab-uki/dynamic-layers/zarhus-encryption/recipes-zarhus/images/otab-encryption.inc
@@ -26,6 +26,7 @@ def get_second_cmdline(d):
     return " ".join(cmdline.split())
 
 # Modified copy with added shrinking of partition by 32 MB before gzipping.
+# nooelint: oelint.vars.spacesassignment
 do_deploy_partitions() {
     part_dir="${WORKDIR}/build-wic"
     for partition in "$part_dir"/*.direct.p*; do

--- a/meta-zarhus-features/meta-otab/meta-otab-uki/recipes-core/initrdscripts/initramfs-framework/create_overlay
+++ b/meta-zarhus-features/meta-otab/meta-otab-uki/recipes-core/initrdscripts/initramfs-framework/create_overlay
@@ -24,7 +24,7 @@ create_overlay_run() {
     echo "Creating <OTAB_LABEL_ROOTFS_OVERLAY> partition"
 # 1st - create new partition, use recommended values
 # 2nd - set partlabel of last (default) partition to <OTAB_LABEL_ROOTFS_OVERLAY>
-    fdisk "/dev/$disk" <<EOF >/dev/null
+    fdisk "/dev/$disk" <<EOF >/dev/null 2>&1
 n
 
 

--- a/meta-zarhus-features/meta-zarhus-encryption/recipes-core/initrdscripts/initramfs-framework/encrypt_decrypt
+++ b/meta-zarhus-features/meta-zarhus-encryption/recipes-core/initrdscripts/initramfs-framework/encrypt_decrypt
@@ -67,7 +67,7 @@ encrypt_device() {
         device_size="$(lsblk -nbo SIZE "$device_to_encrypt")"
         e2fsck -fp "$device_to_encrypt" >/dev/null
         # reduce fs size to make space for LUKS2 header
-        resize2fs "$device_to_encrypt" "$(($device_size/1024/1024-32))M" -f >/dev/null
+        resize2fs "$device_to_encrypt" "$(($device_size/1024/1024-32))M" -f >/dev/null 2>&1
         error_check "Failed to shrink filesystem"
     fi
     echo "Encrypting $device_to_encrypt"
@@ -85,7 +85,7 @@ encrypt_device() {
     error_check "Couldn't decrypt $device_to_encrypt"
     if [ -n "$reencrypt" ]; then
         echo "n" | e2fsck -f -p "/dev/mapper/$luks_label" >/dev/null
-        resize2fs "/dev/mapper/$luks_label" >/dev/null
+        resize2fs "/dev/mapper/$luks_label" >/dev/null 2>&1
     fi
     echo "Successfully encrypted $device_to_encrypt"
 


### PR DESCRIPTION
Hides `GPT PMBR size mismatch [...] will be corrected by write.` warning and resize2fs version output.