### PR TITLE
Tests and encryption

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ exclude: |
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-added-large-files
       - id: check-merge-conflict
@@ -44,13 +44,13 @@ repos:
           - commit-msg
 
   - repo: https://github.com/koalaman/shellcheck-precommit
-    rev: v0.10.0
+    rev: v0.11.0
     hooks:
       - id: shellcheck
         args: ["--severity=warning"]
 
   - repo: https://github.com/priv-kweihmann/oelint-adv
-    rev: 8.1.2
+    rev: 9.0.1
     hooks:
       - id: oelint-adv
         args: [--rulefile=.oelint-ruleset.json, --hide=info, --quiet, --fix, --constantmods=+.oelint-custom-overrides.json]
@@ -71,7 +71,7 @@ repos:
       - id: codespell
 
   - repo: https://github.com/3mdeb/hooks
-    rev: v0.1.4
+    rev: v0.2.2
     hooks:
       - id: namespell
         args: [--fix]

--- a/meta-zarhus-features/meta-otab/meta-otab-uki/dynamic-layers/zarhus-encryption/recipes-test/cukinia/cukinia/encryption.conf
+++ b/meta-zarhus-features/meta-otab/meta-otab-uki/dynamic-layers/zarhus-encryption/recipes-test/cukinia/cukinia/encryption.conf
@@ -1,54 +1,9 @@
-check_keyslots() {
-    luks_dump="$1"
-    jq_arg='
-    {
-        tpm_keyslots: [.tokens[] | select((.type == "systemd-tpm2") or (.type == "systemd-recovery")) | .keyslots[]],
-        all_keyslots: [.keyslots | keys[] | tonumber]
-    } | select(((.all_keyslots | length) - (.tpm_keyslots | length)) != 0) | error("Not all keyslots use TPM2 or recovery key")
-    '
-    echo "$luks_dump" | jq "$jq_arg"
-}
-
-check_keyslot_at_least_one() {
-    luks_dump="$1"
-    type="$2"
-    jq_arg="
-    [.tokens[] | select(.type == \"${type}\") | .keyslots[]] | select(length == 0) | error(\"No ${type} keyslots used\")
-    "
-    echo "$luks_dump" | jq "$jq_arg"
-}
-
-df_source() {
-    df "$1" --output=source 2>/dev/null | sed 1d
-}
-
-realpath_df_source() {
-    realpath "$(df_source "$1")" 2>/dev/null
-}
+source "$(dirname "${BASH_SOURCE[0]}")/encryption-common.sh"
 
 get_swupdate_default_bootloader() {
     temp=$(mktemp)
     swupdate -vnci "$temp" 2>&1 | grep -o "Using default bootloader interface:.*" | sed 's/.*: //'
     rm "$temp"
-}
-
-test_partition() {
-    part_device="$1"
-    part_name="$2"
-
-    cukinia_log "Test ${part_name}"
-    if as "Check if ${part_device} is encrypted" cukinia_cmd cryptsetup status "${part_device}";
-    then
-        encrypted_device=$(cryptsetup status "${part_device}" | sed -n "s|.*device:.*\(/dev/.*\)|\1|p")
-        luks_dump=$(cryptsetup luksDump "${encrypted_device}" --dump-json-metadata 2>/dev/null)
-        ret=$?
-        if as "Check if we can get rootfs LUKS device information dump" cukinia_test $ret -eq 0;
-        then
-            as "Check if rootfs can only be decrypted with TPM2 or recovery key" cukinia_cmd check_keyslots "${luks_dump}"
-            as "Check if rootfs can be decrypted via TPM2" cukinia_cmd check_keyslot_at_least_one "${luks_dump}" "systemd-tpm2"
-            as "Check if rootfs can be decrypted via recovery key" cukinia_cmd check_keyslot_at_least_one "${luks_dump}" "systemd-recovery"
-        fi
-    fi
 }
 
 section "Encryption feature"

--- a/meta-zarhus-features/meta-otab/meta-otab-uki/recipes-support/swupdate/swupdate_%.bbappend
+++ b/meta-zarhus-features/meta-otab/meta-otab-uki/recipes-support/swupdate/swupdate_%.bbappend
@@ -3,7 +3,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 DEPENDS:append = " efivar"
 
 SRC_URI:remove = "git://github.com/sbabic/swupdate.git;protocol=https;branch=${SRCBRANCH}"
-SRC_URI:append = " git://github.com/3mdeb/swupdate.git;protocol=https;branch=${SRCBRANCH}"
+SRC_URI:prepend = "git://github.com/3mdeb/swupdate.git;protocol=https;branch=${SRCBRANCH} "
 SRCBRANCH = "efivar"
 # nooelint: oelint.append.protvars
 SRCREV = "7dd732c02ee1e682b88ddb155e12d809212d4112"

--- a/meta-zarhus-features/meta-zarhus-encryption/recipes-core/initrdscripts/initramfs-framework/encrypt_decrypt
+++ b/meta-zarhus-features/meta-zarhus-encryption/recipes-core/initrdscripts/initramfs-framework/encrypt_decrypt
@@ -145,7 +145,7 @@ encrypt_decrypt_run() {
         if ! cryptsetup open --token-only "$rd_luks_rootfs" "$rootfs_luks_label" 2>/dev/null; then
             ask_for_password_no_verify >key
             password="--key-file=key"
-            cryptsetup open $password "$rd_luks_rootfs" "$rootfs_luks_label"
+            cryptsetup open $password "$rd_luks_rootfs" "$rootfs_luks_label" 2>/dev/null
         fi
         error_check "Couldn't decrypt $rd_luks_rootfs"
 
@@ -161,7 +161,7 @@ encrypt_decrypt_run() {
             if [ "$rootfs_luks_label" = "$luks_label" ]; then
                 continue
             fi
-            if ! cryptsetup open $password "$decrypt_device" "$luks_label"; then
+            if ! cryptsetup open $password "$decrypt_device" "$luks_label" 2>/dev/null; then
                 echo "Couldn't decrypt $decrypt_device"
             fi
         done

--- a/meta-zarhus-features/meta-zarhus-encryption/recipes-test/cukinia/cukinia/encryption-common.sh
+++ b/meta-zarhus-features/meta-zarhus-encryption/recipes-test/cukinia/cukinia/encryption-common.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+return_code() {
+    return "${1:$?}"
+}
+
+test_partition() {
+    part_device="$1"
+    part_name="$2"
+
+    section "Test ${part_name}" "cyan"
+    if as "Check if ${part_device} is encrypted" cukinia_cmd cryptsetup status "${part_device}";
+    then
+        encrypted_device=$(cryptsetup status "${part_device}" | sed -n "s|.*device:.*\(/dev/.*\)|\1|p")
+        as "Check if we can get '${part_name}' LUKS device information dump" \
+            cukinia_cmd cryptsetup luksDump "${encrypted_device}" --dump-json-metadata
+    fi
+}

--- a/meta-zarhus-features/meta-zarhus-encryption/recipes-test/cukinia/cukinia/encryption.conf
+++ b/meta-zarhus-features/meta-zarhus-encryption/recipes-test/cukinia/cukinia/encryption.conf
@@ -1,31 +1,4 @@
-check_keyslots() {
-    luks_dump="$1"
-    jq_arg='
-    {
-        tpm_keyslots: [.tokens[] | select((.type == "systemd-tpm2") or (.type == "systemd-recovery")) | .keyslots[]],
-        all_keyslots: [.keyslots | keys[] | tonumber]
-    } | select(((.all_keyslots | length) - (.tpm_keyslots | length)) != 0) | error("Not all keyslots use TPM2 or recovery key")
-    '
-    echo "$luks_dump" | jq "$jq_arg"
-}
-
-check_keyslot_at_least_one() {
-    luks_dump="$1"
-    type="$2"
-    jq_arg="
-    [.tokens[] | select(.type == \"${type}\") | .keyslots[]] | select(length == 0) | error(\"No ${type} keyslots used\")
-    "
-    echo "$luks_dump" | jq "$jq_arg"
-}
+source "$(dirname "${BASH_SOURCE[0]}")/encryption-common.sh"
 
 section "Encryption feature"
-if as "Check if rootfs is encrypted" cukinia_cmd cryptsetup status "$(df / --output=source | tail -1)";
-then
-    encrypted_device=$(cryptsetup status "$(df / --output=source | tail -1)" | sed -n "s|.*device:.*\(/dev/.*\)|\1|p")
-    luks_dump=$(cryptsetup luksDump "$encrypted_device" --dump-json-metadata 2>/dev/null)
-    ret=$?
-    as "Check if we can get rootfs LUKS device information dump" cukinia_test $ret -eq 0
-    as "Check if rootfs can only be decrypted with TPM2 or recovery key" cukinia_cmd check_keyslots "$luks_dump"
-    as "Check if rootfs can be decrypted via TPM2" cukinia_cmd check_keyslot_at_least_one "$luks_dump" "systemd-tpm2"
-    as "Check if rootfs can be decrypted via recovery key" cukinia_cmd check_keyslot_at_least_one "$luks_dump" "systemd-recovery"
-fi
+test_partition "$(df / --output=source | tail -1)" "rootfs"

--- a/meta-zarhus-features/meta-zarhus-encryption/recipes-test/cukinia/cukinia_%.bbappend
+++ b/meta-zarhus-features/meta-zarhus-encryption/recipes-test/cukinia/cukinia_%.bbappend
@@ -1,10 +1,18 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
-SRC_URI += "file://encryption.conf"
-FILES:${PN} += "${sysconfdir}/cukinia/conf.d/encryption.conf"
+SRC_URI += " \
+    file://encryption.conf \
+    file://encryption-common.sh \
+"
+FILES:${PN} += " \
+    ${sysconfdir}/cukinia/conf.d/encryption.conf \
+    ${sysconfdir}/cukinia/conf.d/encryption-common.sh \
+"
+
 RDEPENDS:${PN} += " jq"
 
 do_install:append() {
     install -d "${D}${sysconfdir}/cukinia/conf.d"
     install -m "0644" "${WORKDIR}/encryption.conf" "${D}${sysconfdir}/cukinia/conf.d/"
+    install -m "0644" "${WORKDIR}/encryption-common.sh" "${D}${sysconfdir}/cukinia/conf.d/"
 }


### PR DESCRIPTION
Before (testing debug image so root account is unlocked and this test fails):

```
genericx86-64:~$ sudo cukinia
```

**Results:**

```
[PASS]  Check if cukinia is run with root privileges
----> encryption.conf <----
----> Encryption feature <----
Test rootfs partition A
[PASS]  Check if /dev/disk/by-label/rootfs_a is encrypted
[PASS]  Check if we can get rootfs LUKS device information dump
[FAIL]  Check if rootfs can only be decrypted with TPM2 or recovery key
[FAIL]  Check if rootfs can be decrypted via TPM2
[FAIL]  Check if rootfs can be decrypted via recovery key
Test rootfs partition B
[PASS]  Check if /dev/disk/by-label/rootfs_b is encrypted
[PASS]  Check if we can get rootfs LUKS device information dump
[FAIL]  Check if rootfs can only be decrypted with TPM2 or recovery key
[FAIL]  Check if rootfs can be decrypted via TPM2
[FAIL]  Check if rootfs can be decrypted via recovery key
Test rootfs overlay partition
[PASS]  Check if /dev/disk/by-label/rwoverlay is encrypted
[PASS]  Check if we can get rootfs LUKS device information dump
[FAIL]  Check if rootfs can only be decrypted with TPM2 or recovery key
[FAIL]  Check if rootfs can be decrypted via TPM2
[FAIL]  Check if rootfs can be decrypted via recovery key
----> hardening.conf <----
----> Users <----
[PASS]  Checking user "user" exists
[PASS]  Checking user "user" is member of "user sudo"
[FAIL]  Check if root account is locked
----> Kernel lockdown feature <----
[PASS]  Check if access to /dev/mem is restricted
[PASS]  Check if kernel lockdown is enabled
[PASS]  Check dmesg for blocked access to /dev/mem
----> otab.conf <----
----> A/B feature <----
[PASS]  Check if boot partition A exists
[PASS]  Check if boot partition B exists
[PASS]  Check if rootfs partition A exists
[PASS]  Check if rootfs partition B exists
[PASS]  Check if rwoverlay partition exists
[PASS]  Check if / is mounted as overlay
[PASS]  Check if /media/rfs/ro is read-only
[PASS]  Check if correct partition (A) is mounted on /media/rfs/ro
[PASS]  Check if swupdate is configured to use efivar bootloader
[PASS]  Checking if systemd unit "initramfs-shutdown.service" is active
result: 10 failure(s)
```

After:

<img width="691" height="660" alt="image" src="https://github.com/user-attachments/assets/3921681b-c0f0-4b99-aa4d-2f2c5ee21bb3" />

<details><summary>Text log</summary>
<p>

```
[PASS]  Check if cukinia is run with root privileges
----> encryption.conf <----
----> Encryption feature <----
----> Test rootfs partition A <----
[PASS]  Check if /dev/disk/by-label/rootfs_a is encrypted
[PASS]  Check if we can get 'rootfs partition A' LUKS device information dump
----> Test rootfs partition B <----
[PASS]  Check if /dev/disk/by-label/rootfs_b is encrypted
[PASS]  Check if we can get 'rootfs partition B' LUKS device information dump
----> Test rootfs overlay partition <----
[PASS]  Check if /dev/disk/by-label/rwoverlay is encrypted
[PASS]  Check if we can get 'rootfs overlay partition' LUKS device information dump
----> hardening.conf <----
----> Users <----
[PASS]  Checking user "user" exists
[PASS]  Checking user "user" is member of "user sudo"
[FAIL]  Check if root account is locked
----> Kernel lockdown feature <----
[PASS]  Check if access to /dev/mem is restricted
[PASS]  Check if kernel lockdown is enabled
[PASS]  Check dmesg for blocked access to /dev/mem
----> otab.conf <----
----> A/B feature <----
[PASS]  Check if boot partition A exists
[PASS]  Check if boot partition B exists
[PASS]  Check if rootfs partition A exists
[PASS]  Check if rootfs partition B exists
[PASS]  Check if rwoverlay partition exists
[PASS]  Check if / is mounted as overlay
[PASS]  Check if /media/rfs/ro is read-only
[PASS]  Check if correct partition (A) is mounted on /media/rfs/ro
[PASS]  Check if swupdate is configured to use efivar bootloader
[PASS]  Checking if systemd unit "initramfs-shutdown.service" is active
result: 1 failure(s)
```

</p>
</details> 

Removed tests:

```
[FAIL]  Check if rootfs can only be decrypted with TPM2 or recovery key
[FAIL]  Check if rootfs can be decrypted via TPM2
[FAIL]  Check if rootfs can be decrypted via recovery key 
```

because:

- recovery key - we use password instead of recovery key now
- TPM2 - enrolling is done manually after OS/firmware preparation and is optional. If TPM tests are needed then they should be done in e.g. OSFV.

---

Also fixes TPM2 errors if PCRs change e.g. when rerunning QEMU:

```
Starting systemd-udevd version 255.13^
Enter disk encryption password:
Mounting rw filesystem using overlay...

Distro for Zarhus product 0.1.0 genericx86-64 ttyS0

genericx86-64 login: user
Password:

genericx86-64:~$ sudo cryptsetup luksDump /dev/sda3 | grep -i tpm2 -B1
Tokens:
  0: systemd-tpm2
```

To make sure that those errors were really there, just hidden I tried to decrypt partition manually, without redirecting stderr output to `/dev/null` and I got expected errors:

```
genericx86-64:~$ sudo cryptsetup open /dev/sda4 luks_rootfs_b
WARNING:esys:/usr/src/debug/tpm2-tss/4.0.2/src/tss2-esys/api/Esys_Load.c:324:Esys_Load_Finish() Received TPM Error
ERROR:esys:/usr/src/debug/tpm2-tss/4.0.2/src/tss2-esys/api/Esys_Load.c:112:Esys_Load() Esys Finish ErrorCode (0x0000018b)
Failed to unseal secret using TPM2: State not recoverable
Enter passphrase for /dev/sda4:
```

---

Results for meta-zarhus image without A/B update feature:

```
[PASS]  Check if cukinia is run with root privileges
----> encryption.conf <----
----> Encryption feature <----
----> Test rootfs <----
[PASS]  Check if /dev/disk/by-label/rootfs is encrypted
[PASS]  Check if we can get 'rootfs' LUKS device information dump
----> hardening.conf <----
----> Users <----
[PASS]  Checking user "user" exists
[PASS]  Checking user "user" is member of "user sudo"
[FAIL]  Check if root account is locked
----> Kernel lockdown feature <----
[PASS]  Check if access to /dev/mem is restricted
[PASS]  Check if kernel lockdown is enabled
[PASS]  Check dmesg for blocked access to /dev/mem
result: 1 failure(s)
```